### PR TITLE
make egithub_webhook:request() type opaque

### DIFF
--- a/src/egithub_webhook_req.erl
+++ b/src/egithub_webhook_req.erl
@@ -1,0 +1,35 @@
+%%% @doc egithub webhook request module for handling
+%%%      the opaque request data type.
+%%%      this is used internally by the egithub_webhook module
+
+-module(egithub_webhook_req).
+
+-opaque request() :: #{headers => map(), body => map()|binary()}.
+-export_type([request/0]).
+
+%% API
+-export([new/2, headers/1, header/2, header/3, payload/1]).
+
+-spec new(map(), binary()|map()) -> request().
+new(Headers, Body) -> #{headers => Headers, body => Body}.
+
+-spec headers(request()) -> map().
+headers(#{headers := Headers}) -> Headers.
+
+-spec header(binary(), request()) -> binary()|undefined.
+header(Header, Request) -> header(Header, Request, undefined).
+
+-spec header(binary(), request(), binary()|undefined) -> binary()|undefined.
+header(Header, #{headers := Headers}, Default) ->
+  maps:get(Header, Headers, Default).
+
+-spec payload(request()) -> {request(), map()}.
+payload(Request=#{body := Body}) when is_binary(Body)->
+  with_decoded_body(Request);
+payload(Request=#{body := DecodedBody}) when is_map(DecodedBody) ->
+  {Request, DecodedBody}.
+
+-spec with_decoded_body(request()) -> {request(), map()}.
+with_decoded_body(Request=#{body := Body}) ->
+  DecodedBody = egithub_json:decode(Body),
+  {Request#{body => DecodedBody}, DecodedBody}.

--- a/test/egithub_webhook_req_SUITE.erl
+++ b/test/egithub_webhook_req_SUITE.erl
@@ -1,0 +1,92 @@
+-module(egithub_webhook_req_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+%% API
+-export([
+  all/0,
+  init_per_suite/1,
+  end_per_suite/1
+]).
+
+-export([
+  get_headers/1,
+  encoded_body/1,
+  decoded_body/1
+]).
+
+-define(EXCLUDED_FUNS,
+  [
+    module_info,
+    all,
+    init_per_suite,
+    end_per_suite,
+    setup_test_data
+  ]).
+
+-type config() :: [{atom(), term()}].
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Common test
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec all() -> [atom()].
+all() ->
+  Exports = ?MODULE:module_info(exports),
+  [F || {F, _} <- Exports, not lists:member(F, ?EXCLUDED_FUNS)].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  {ok, _} = egithub:start(),
+  application:unset_env(egithub, json),
+  [{test_data, setup_test_data()} | Config].
+
+-spec end_per_suite(config()) -> config().
+end_per_suite(Config) ->
+  ok = application:stop(egithub),
+  Config.
+
+setup_test_data() ->
+  EncodedBody = <<"{\"foo\":\"bar\"}">>,
+  DecodedBody = egithub_json:decode(EncodedBody),
+  TestHeaders = #{<<"Accept">> => <<"*">>,
+    <<"Content-Type">> => <<"application/json">>},
+  EncodedReq = egithub_webhook_req:new(TestHeaders, EncodedBody),
+  DecodedReq = egithub_webhook_req:new(TestHeaders, DecodedBody),
+  #{
+    encoded_body => EncodedBody,
+    decoded_body => DecodedBody,
+    headers => TestHeaders,
+    encoded_request => EncodedReq,
+    decoded_request => DecodedReq
+  }.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Test cases
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+get_headers(Config) ->
+  #{
+    headers := TestHeaders,
+    encoded_request := Req
+  } = ?config(test_data, Config),
+
+  TestHeaders = egithub_webhook_req:headers(Req),
+  undefined = egithub_webhook_req:header(<<"Undefined">>, Req),
+  <<"*">> = egithub_webhook_req:header(<<"Accept">>, Req).
+
+encoded_body(Config) ->
+  #{
+    encoded_request := Req,
+    decoded_body := DecodedBody
+  } = ?config(test_data, Config),
+
+  {Req2, DecodedBody} = egithub_webhook_req:payload(Req),
+  {_Req3, DecodedBody} = egithub_webhook_req:payload(Req2).
+
+decoded_body(Config) ->
+  #{
+    decoded_request := Req,
+    decoded_body := DecodedBody
+  } = ?config(test_data, Config),
+
+  {Req, DecodedBody} = egithub_webhook_req:payload(Req).


### PR DESCRIPTION
and move creation and extraction into its own module.

this solves #117

though i actually didn't see any place in erlang-githubs codebase where a requests body was accessed multiple times.
