### PR TITLE
Add stacktrace_compat to the mix resolves #164

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,7 @@
 
 {profiles, [
   {test, [
-    {deps, [ {meck,        "0.8.4"}
+    {deps, [ {meck,        "0.8.10"}
            , {katana_test, "0.1.1"}
            , {mixer,       "0.1.5", {pkg, inaka_mixer}}
     ]}

--- a/src/egithub_webhook.erl
+++ b/src/egithub_webhook.erl
@@ -94,13 +94,12 @@ event(Module, StatusCred, ToolName, Context, CommentsCred, Request) ->
         _:Error ->
           _ = lager:warning(
             "event:Error ~p Module: ~p ToolName: ~p "
-            "Context: ~p EventData: ~p get_stacktrace: ~p",
+            "Context: ~p EventData: ~p",
             [ Error
             , Module
             , ToolName
             , Context
-            , EventData
-            , erlang:get_stacktrace()]),
+            , EventData]),
           ErrSource =
             do_handle_error_source(Error, Module, CommentsCred, EventData),
           _ =


### PR DESCRIPTION
Resolves #164 

 Introduce stacktrace_compat dep and erl_opts (parse_transform) for backwards compatibility between OTP <= 20.x and 21