### PR TITLE
Add custom API host

### DIFF
--- a/src/egithub_req.erl
+++ b/src/egithub_req.erl
@@ -53,7 +53,8 @@ run(Cred, Uri, Method, Body) ->
 do_run(Uri, Headers, Method, Body) ->
   _ = lager:info("[Github API] ~s", [Uri]),
   BinUri = iolist_to_binary(Uri),
-  Url = <<"https://api.github.com", BinUri/binary>>,
+  Host = application:get_env(egithub, egithub_host, <<"api.github.com">>),
+  Url = <<"https://", Host/binary, BinUri/binary>>,
   case hackney:request(Method, Url, Headers, Body) of
     {ok, 200, _RespHeaders, ClientRef} ->
       hackney:body(ClientRef);


### PR DESCRIPTION
Currently, this github API client can only work on the public GitHub API.
This is because the host is hard coded to `api.github.com` in
`egithub_req:do_run/4`. To get around this problem so parties who host their
own internal github can use this client, I've gone ahead and made the github
host an application env lookup with the default set to `api.github.com`. This
maintains backwards compatibility for current users, while allowing the
flexibility to set a custom API host.

To set a custom host add an entry like this:
```
{egithub, [
   {egithub_host, <<"custom.github.api.com">>}
]}
```
to your `sys.config`.