### PR TITLE
Move to a GitHub action (instead of container-based) CI approach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
   ci:
     name: Run checks and tests over ${{matrix.otp_vsn}} and ${{matrix.os}}
     runs-on: ${{matrix.os}}
-    container:
-      image: erlang:${{matrix.otp_vsn}}
     strategy:
       matrix:
-        otp_vsn: [21.3, 22.3, 23.2]
+        otp_vsn: [21, 22, 23]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - run: rebar3 --version
-      - run: erl -version
+      - uses: erlef/setup-beam@v1.7.0
+        with:
+          otp-version: ${{matrix.otp_vsn}}
+          rebar3-version: '3.14'
       - run: rebar3 as test lint
       - run: rebar3 dialyzer
       - run: rebar3 ct


### PR DESCRIPTION
Also, that GitHub action is now the "official" action for Erlang+rebar3 CI, as per EEF